### PR TITLE
[BOUNTY] Swap boot order for Hexagon ADSP and SLPI

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -58,8 +58,8 @@ on early-boot
     write /sys/module/pil_msa/parameters/pbl_mba_boot_timeout_ms ${persist.sys.mba_boot_timeout}
     write /sys/module/pil_msa/parameters/modem_auth_timeout_ms ${persist.sys.modem_auth_timeout}
     write /sys/module/peripheral_loader/parameters/proxy_timeout_ms ${persist.sys.pil_proxy_timeout}
-    write /sys/kernel/boot_adsp/boot 1
     write /sys/kernel/boot_slpi/boot 1
+    write /sys/kernel/boot_adsp/boot 1
 
 on fs
     wait /dev/block/bootdevice


### PR DESCRIPTION
This is intended to resolve commaai/openpilot#1130, which is an issue with the Hexagon DSP SLPI (Sensor Low Power Island) timing out on startup after ~1% of bootups.

Testing showed that varying certain kernel parameters (like the NEOS CPU speed locking and NEOS predefined interrupt affinity table) could mitigate the problem, but it wasn't really clear why, and the particular combinations that worked were strange ones that I couldn't draw causal lines from.

Other Android distributions start the DSP components at different stages of the boot cycle, and sometimes in a different order than NEOS does. Approaching it as a possible timing issue with the DSP alone, I tried a minimal change to the userland startup sequence, and that seems to have killed the problem dead by itself. Zero failures after 1,614 tests.